### PR TITLE
fix: require python 3.10.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "readyplayerme-pyblish-plugins"
 dynamic = ["version"]
 description = "Pyblish plugins for Ready Player Me asset validation within 3D content creation software."
 readme = "README.md"
-requires-python = "~=3.10"
+requires-python = "~=3.10.0"
 license = "MIT"
 keywords = ["ready player me", "3D", "validation", "pyblish", "blender"]
 authors = [


### PR DESCRIPTION
# Description

There are problems with the installation of dev dependencies (bpy 3.6.0) if Python > 3.10.
This PR tries to restrict the compatible Python versions to 3.10.x

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update